### PR TITLE
Allow arrow functions in React JSX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patrikvalkovic/eslint-config",
-  "version": "1.0.4",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@patrikvalkovic/eslint-config",
-      "version": "1.0.4",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patrikvalkovic/eslint-config",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Opinionated eslint config",
   "repository": {
     "type": "git",

--- a/src/react.ts
+++ b/src/react.ts
@@ -131,6 +131,12 @@ const config = (config: ConfigOrTsPath, overrides?: Config) => {
                 'react/jsx-sort-default-props': 'off',
                 'react/jsx-sort-props': 'off',
                 'react/jsx-space-before-closing': 'off',
+                'react/jsx-no-bind': [
+                    'error',
+                    {
+                        'allowArrowFunctions': true,
+                    },
+                ],
                 'react/no-adjacent-inline-elements': 'off',
                 'react/no-multi-comp': [
                     'error',


### PR DESCRIPTION
Edits, react/jsx-no-bind rule. Allows arrow functions to be used in JSX.